### PR TITLE
Add scripts to autoinstall workshoppers

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -15,26 +15,26 @@ echo "---------------------------------------------"
 
 # install heroku toolbelt
 echo "-------------- Installing heroku toolbelt -------------------------"
-#wget -O- https://toolbelt.heroku.com/install-ubuntu.sh | sh
+wget -O- https://toolbelt.heroku.com/install-ubuntu.sh | sh
 # These shell script snippets are directly taken from heroku installation script
 # We want to avoid the apt-get update
 # add heroku repository to apt
 echo "deb http://toolbelt.heroku.com/ubuntu ./" > /etc/apt/sources.list.d/heroku.list
 # install heroku's release key for package verification
-#wget -O- https://toolbelt.heroku.com/apt/release.key 2>&1 | apt-key add -
+wget -O- https://toolbelt.heroku.com/apt/release.key 2>&1 | apt-key add -
 
 echo "---------------------------------------------"
 echo "------- Updating package dependencies -------"
 echo "---------------------------------------------"
-#apt-get update -y # no need for sudo, and -y is needed to bypass the yes-no
+apt-get update -y # no need for sudo, and -y is needed to bypass the yes-no
 
 echo "---------------------------------------------"
 echo "-------- Installing packages ----------------"
 echo "---------------------------------------------"
 # install gcc and g++ and other build basics to ensure most software works
-#apt-get install -y --no-install-recommends heroku-toolbelt build-essential
+apt-get install -y --no-install-recommends heroku-toolbelt build-essential
 # install the cli
-#su - vagrant -c "heroku --version > /dev/null 2>&1"
+su - vagrant -c "heroku --version > /dev/null 2>&1"
 
 echo "---------------------------------------------"
 echo "-------- Installing NVM & Node --------------"

--- a/provision.sh
+++ b/provision.sh
@@ -3,7 +3,6 @@
 # installation settings
 PROJECT="nodeschool" # we would want a name passed to it via te first argument, $1
 DB="nodeschool" # the name of postgreSQL DB we need to provision, maybe $2
-NVM_DIR="/home/vagrant/.nvm"
 
 # This file is executed by root user - sudo not needed
 # But do not create any directory
@@ -22,20 +21,20 @@ echo "-------------- Installing heroku toolbelt -------------------------"
 # add heroku repository to apt
 echo "deb http://toolbelt.heroku.com/ubuntu ./" > /etc/apt/sources.list.d/heroku.list
 # install heroku's release key for package verification
-wget -O- https://toolbelt.heroku.com/apt/release.key 2>&1 | apt-key add -
+#wget -O- https://toolbelt.heroku.com/apt/release.key 2>&1 | apt-key add -
 
 echo "---------------------------------------------"
 echo "------- Updating package dependencies -------"
 echo "---------------------------------------------"
-apt-get update -y # no need for sudo, and -y is needed to bypass the yes-no
+#apt-get update -y # no need for sudo, and -y is needed to bypass the yes-no
 
 echo "---------------------------------------------"
 echo "-------- Installing packages ----------------"
 echo "---------------------------------------------"
 # install gcc and g++ and other build basics to ensure most software works
-apt-get install -y --no-install-recommends heroku-toolbelt build-essential
+#apt-get install -y --no-install-recommends heroku-toolbelt build-essential
 # install the cli
-su - vagrant -c "heroku --version > /dev/null 2>&1"
+#su - vagrant -c "heroku --version > /dev/null 2>&1"
 
 echo "---------------------------------------------"
 echo "-------- Installing NVM & Node --------------"
@@ -44,20 +43,50 @@ echo "---------------------------------------------"
 # install nvm
 su - vagrant -c "wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.31.1/install.sh | bash"
 
-# source bash
-su - vagrant -c "source ~/.bashrc"
+# source bash and install node
+su - vagrant <<NVM
 
-# install node
-su - vagrant -c "nvm install v4.4.3"
+source ~/.nvm/nvm.sh
+echo 'sourcing done'
+nvm install 4.4.3
+
+NVM
 
 echo "---------------------------------------------"
 echo "--- Installing Workshopper modules ----------"
 echo "---------------------------------------------"
-## install nodeschool-workshopper modules
 
-su - vagrant -c "npm i -g javascripting learnyounode git-it how-to-npm scope-chains-closures stream-adventure"
-su - vagrant -c "npm i -g elementary-electron how-to-markdown functional-javascript-workshop expressworks"
-su - vagrant -c "npm i -g promise-it-wont-hurt count-to-6"
+su - vagrant <<WORKSHOPPERS
+
+source ~/.nvm/nvm.sh
+echo "Installing javascripting ..."
+npm i -g javascripting
+echo "Installing learnyounode ..."
+npm i -g learnyounode
+echo "Installing git-it ..."
+npm i -g git-it
+echo "Installing how-to-npm ..."
+npm i -g how-to-npm
+echo "Installing scope-chains-closures ..."
+npm i -g scope-chains-closures
+echo "Installing stream-adventure ..."
+npm i -g stream-adventure
+echo "Installing elementary-electron ..."
+npm i -g elementary-electron
+echo "Installing how-to-markdown ..."
+npm i -g how-to-markdown
+echo "Installing functional-javascript-workshop ..."
+npm i -g functional-javascript-workshop
+echo "Installing expressworks ..."
+npm i -g expressworks
+echo "Installing promise-it-wont-hurt ..."
+npm i -g promise-it-wont-hurt
+echo "Installing count-to-6 ..."
+npm i -g count-to-6
+
+echo "All workshoppers installed."
+
+WORKSHOPPERS
 
 echo "---------------------------------------------"
 echo " Done! Run vagrant ssh to start working "


### PR DESCRIPTION
After much testing, I found this is the way to install the workshopper modules in order to avoid the [sourcing bashrc within provisioning](http://superuser.com/questions/931399/sourcing-bashrc-does-not-enable-use-of-nvm) problem. Please review @alayek @abhisekp 
